### PR TITLE
Support for transport products via Octo Api / octo/content

### DIFF
--- a/FjordTours.App.DistributorApi/FjordTours.App.DistributorApi.csproj
+++ b/FjordTours.App.DistributorApi/FjordTours.App.DistributorApi.csproj
@@ -2,7 +2,7 @@
 		
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
-		<Version>3.0.1</Version>
+		<Version>3.1.0</Version>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -13,20 +13,20 @@
 	<ItemGroup>
 		<PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
 		<PackageReference Include="Faker.Data" Version="2.0.1" />
-		<PackageReference Include="FjordTours.DistributorApi.Auth" Version="4.3.0" />
-		<PackageReference Include="FjordTours.DistributorApi.Common" Version="4.3.0" />
-		<PackageReference Include="FjordTours.DistributorApi.Octo" Version="4.3.0" />
-		<PackageReference Include="FjordTours.DistributorApi.Osdm" Version="4.3.0" />
-		<PackageReference Include="FjordTours.DistributorApi.Proprietary" Version="4.3.0" />
+		<PackageReference Include="FjordTours.DistributorApi.Auth" Version="4.5.0" />
+		<PackageReference Include="FjordTours.DistributorApi.Common" Version="4.5.0" />
+		<PackageReference Include="FjordTours.DistributorApi.Octo" Version="4.5.0" />
+		<PackageReference Include="FjordTours.DistributorApi.Osdm" Version="4.5.0" />
+		<PackageReference Include="FjordTours.DistributorApi.Proprietary" Version="4.5.0" />
 		<PackageReference Include="Humanizer" Version="3.0.10" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.5" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.5" />
-		<PackageReference Include="Microsoft.Extensions.AI" Version="10.4.0" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.9" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.AI" Version="10.7.0" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
 		<PackageReference Include="ModelContextProtocol" Version="0.2.0-preview.3" />
 		<PackageReference Include="MudBlazor" Version="8.10.0" />
 		<PackageReference Include="MudBlazor.Markdown" Version="8.9.0" />
-		<PackageReference Include="OllamaSharp" Version="5.4.23" />
+		<PackageReference Include="OllamaSharp" Version="5.4.25" />
 	</ItemGroup>
 	
 </Project>

--- a/FjordTours.App.DistributorApi/Layout/MainLayout.razor
+++ b/FjordTours.App.DistributorApi/Layout/MainLayout.razor
@@ -1,6 +1,4 @@
-﻿@using FjordTours.App.DistributorApi.Components
-@using FjordTours.DistributorApi.Auth.Config
-
+﻿
 @inherits LayoutComponentBase
 
 <MudThemeProvider />
@@ -31,7 +29,7 @@
         <NavMenu />
     </MudDrawer>
 
-    <MudMainContent>
+    <MudMainContent Class="pa-5 mt-15">
         @Body
     </MudMainContent>
 

--- a/FjordTours.App.DistributorApi/Pages/DashboardPage.razor
+++ b/FjordTours.App.DistributorApi/Pages/DashboardPage.razor
@@ -7,38 +7,51 @@
 
 <PageTitle>Dashboard</PageTitle>
 
-<h1>Dashboard</h1>
+<MudGrid>
+    <MudItem xs="12">
+        <h1>Dashboard</h1>
+    </MudItem>
 
-<h2>Distributor</h2>
+    
+    <MudItem xs="12">
+        <MudAlert Severity="Severity.Warning">
+            Api is under development / experimental and support has not yet been added to this test / demo tool.
+        </MudAlert>
+    </MudItem>
 
-<MudAlert Severity="Severity.Info">
-    <h3>@AppState?.DistributorProfile?.Name.ToHyphenIfNullOrEmpty()</h3>
-    Registration Number: <b>@AppState?.DistributorProfile?.RegistrationNumber</b><br />
-    Current Contract type: <b>@AppState?.DistributorProfile?.CurrentContractType</b><br />
-</MudAlert>
+    <MudItem xs="12">
+        <h2>Distributor</h2>
 
+        <MudAlert Severity="Severity.Info">
+            <h3>@AppState?.DistributorProfile?.Name.ToHyphenIfNullOrEmpty()</h3>
+            Registration Number: <b>@AppState?.DistributorProfile?.RegistrationNumber</b><br />
+            Current Contract type: <b>@AppState?.DistributorProfile?.CurrentContractType</b><br />
+        </MudAlert>
+    </MudItem>
 
-<h2>Proprietary Api</h2>
+    <MudItem xs="12">
+        <h2>Proprietary Api</h2>
 
-<MudAlert Severity="Severity.Info">
-    Proprietary Api developed and provided by Fjord Tours.
-    Provides most flexibility, including management and configuration functionality.
-</MudAlert>
+        <MudAlert Severity="Severity.Info">
+            Proprietary Api developed and provided by Fjord Tours.
+            Provides most flexibility, including management and configuration functionality.
+        </MudAlert>
+    </MudItem>
 
+    <MudItem xs="12">
+        <h2>OCTO Api</h2>
 
-<h2>OCTO Api</h2>
+        <MudAlert Severity="Severity.Info">
+            OCTO is an industry standard for ours, activities & attractions.
+        </MudAlert>
+    </MudItem>
 
-<MudAlert Severity="Severity.Info">
-    OCTO is an industry standard for ours, activities & attractions.
-</MudAlert>
+    <MudItem xs="12">
+        <h2>OSDM Api</h2>
 
+        <MudAlert Severity="Severity.Info">
+            OSDM is the Open Sales and Distribution Model developed by various European rail and public transport providers.
+        </MudAlert>
+    </MudItem>
 
-<h2>OSDM Api</h2>
-
-<MudAlert Severity="Severity.Info">
-    OSDM is the Open Sales and Distribution Model developed by various European rail and public transport providers.
-</MudAlert>
-
-<MudAlert Severity="Severity.Warning">
-    Api is under development / experimental and support has not yet been added to this test / demo tool.
-</MudAlert>
+</MudGrid>

--- a/FjordTours.App.DistributorApi/Pages/OctoApi/OctoAvailabilityPage.razor
+++ b/FjordTours.App.DistributorApi/Pages/OctoApi/OctoAvailabilityPage.razor
@@ -1,13 +1,13 @@
 ﻿@page "/octo/activity/offers/{ProductId}/{OptionId}/{TravelDate:datetime}"
+
 @using FjordTours.App.DistributorApi.Components
-@using FjordTours.App.DistributorApi.Infrastructure.Constants
 @using FjordTours.App.DistributorApi.Infrastructure.Extensions
 @using FjordTours.App.DistributorApi.Infrastructure.State
-@using FjordTours.DistributorApi.Contracts.Octo
 @using FjordTours.DistributorApi.Common.Constants
-@using FjordTours.DistributorApi.Common.Enums
+@using FjordTours.DistributorApi.Contracts.Octo
 @using FjordTours.OCTO.Common.Dtos.Availability
 @using FjordTours.OCTO.Common.Enums
+
 @inherits AppProtectedPage
 
 <h1>Octo Api - Availabilities (Offers)</h1>
@@ -35,6 +35,7 @@
                     Availabilities/Offers are searched for one adult.
                 </MudAlert>
             </MudItem>
+
             <MudItem xs="12">
                 <h2>Order Data</h2>
                 <MudAlert Severity="Severity.Warning">
@@ -63,17 +64,19 @@
                 <MudText Typo="Typo.h6">Phone</MudText>
                 <MudText Typo="Typo.button">@_phone</MudText>
             </MudItem>
+
             <MudItem xs="12">
                 <h2>Offers</h2>
                 <MudGrid>
                     @foreach (var avail in _availabilities)
                     {
-                        var color = ProductId.StartsWith("activity")
-                            ? Color.Primary
-                            : Color.Info;
-                        var abbr = ProductId.StartsWith("activity")
-                            ? "A"
-                            : "B";
+                        var (color, abbr) = ProductId switch
+                        {
+                            var id when id.StartsWith("activity") => (Color.Primary, "A"),
+                            var id when id.StartsWith("bundle") => (Color.Info, "B"),
+                            var id when id.StartsWith("transport") => (Color.Success, "T"),
+                            _ => (Color.Default, "?")
+                        };
                         <MudItem xs="3">
                             <MudCard style="min-height: 100px;">
                                 <MudCardHeader>
@@ -82,12 +85,16 @@
                                     </CardHeaderAvatar>
                                     <CardHeaderContent>
                                         <MudText Typo="Typo.h6">@avail.Id</MudText>
+                                        <MudText Typo="Typo.h6">@avail.Title</MudText>
                                         <MudText Typo="Typo.button">@avail.AvailabilityStatus.ToString()</MudText>
                                     </CardHeaderContent>
                                 </MudCardHeader>
                                 <MudCardContent>
                                     <MudText>Start - End</MudText>
                                     <MudText Typo="Typo.button">@avail.LocalDateTimeStart.ToDateTimeString() - @avail.LocalDateTimeEnd.ToDateTimeString()</MudText>
+
+                                    <MudText>Short Description</MudText>
+                                    <MudText Typo="Typo.button">@avail.ShortDescription.ToHyphenIfNullOrEmpty()</MudText>
 
                                     <MudText>Availability</MudText>
                                     <MudText Typo="Typo.button">

--- a/FjordTours.App.DistributorApi/Pages/OctoApi/OctoBookingPage.razor
+++ b/FjordTours.App.DistributorApi/Pages/OctoApi/OctoBookingPage.razor
@@ -1,11 +1,13 @@
 ﻿@page "/octo/booking/{BookingId}"
+
+@using System.Timers
 @using FjordTours.App.DistributorApi.Components
 @using FjordTours.App.DistributorApi.Infrastructure.Extensions
 @using FjordTours.App.DistributorApi.Infrastructure.State
-@using System.Timers
-@using FjordTours.DistributorApi.Contracts.Octo
 @using FjordTours.DistributorApi.Common.Constants
+@using FjordTours.DistributorApi.Contracts.Octo
 @using FjordTours.OCTO.Common.Dtos.Booking
+
 @inherits AppProtectedPage
 @implements IDisposable
 

--- a/FjordTours.App.DistributorApi/Pages/OctoApi/OctoBookingsPage.razor
+++ b/FjordTours.App.DistributorApi/Pages/OctoApi/OctoBookingsPage.razor
@@ -1,10 +1,11 @@
 ﻿@page "/octo/bookings"
+
 @using FjordTours.App.DistributorApi.Components
 @using FjordTours.App.DistributorApi.Infrastructure.Extensions
-@using FjordTours.DistributorApi.Contracts.Octo
 @using FjordTours.DistributorApi.Common.Constants
+@using FjordTours.DistributorApi.Contracts.Octo
 @using FjordTours.OCTO.Common.Dtos.Booking
-@using Humanizer
+
 @inherits AppProtectedPage
 
 <h1>Octo Api - Bookings</h1>

--- a/FjordTours.App.DistributorApi/Pages/OctoApi/OctoCalendarPage.razor
+++ b/FjordTours.App.DistributorApi/Pages/OctoApi/OctoCalendarPage.razor
@@ -1,10 +1,12 @@
 ﻿@page "/octo/calendar/{ProductId}/{OptionId}"
+
 @using FjordTours.App.DistributorApi.Components
 @using FjordTours.App.DistributorApi.Infrastructure.Extensions
 @using FjordTours.App.DistributorApi.Infrastructure.State
-@using FjordTours.DistributorApi.Contracts.Octo
 @using FjordTours.DistributorApi.Common.Constants
+@using FjordTours.DistributorApi.Contracts.Octo
 @using FjordTours.OCTO.Common.Dtos.Availability
+
 @inherits AppProtectedPage
 
 <h1>OCTO Api - Availability Calendar</h1>

--- a/FjordTours.App.DistributorApi/Pages/OctoApi/OctoProductsPage.razor
+++ b/FjordTours.App.DistributorApi/Pages/OctoApi/OctoProductsPage.razor
@@ -1,10 +1,11 @@
 ﻿@page "/octo/products"
+
 @using FjordTours.App.DistributorApi.Components
 @using FjordTours.App.DistributorApi.Infrastructure.Extensions
-@using FjordTours.DistributorApi.Contracts.Octo
-@using FjordTours.DistributorApi.Proprietary.Contracts
 @using FjordTours.DistributorApi.Common.Constants
+@using FjordTours.DistributorApi.Contracts.Octo
 @using FjordTours.OCTO.Common.Dtos.Products
+
 @inherits AppProtectedPage
 
 <h1>OCTO API - Products</h1>
@@ -29,12 +30,13 @@
         <MudGrid>
             @foreach (var product in _products)
             {
-                var color = product.Id.StartsWith("activity")
-                    ? Color.Primary
-                    : Color.Info;
-                var abbr = product.Id.StartsWith("activity")
-                    ? "A"
-                    : "B";
+                var (color, abbr) = product.Id switch
+                {
+                    var id when id.StartsWith("activity") => (Color.Primary, "A"),
+                    var id when id.StartsWith("bundle") => (Color.Info, "B"),
+                    var id when id.StartsWith("transport") => (Color.Success, "T"),
+                    _ => (Color.Default, "?")
+                };
                 <MudItem xs="3">
                     <MudCard style="min-height: 100px;">
                         <MudCardHeader>
@@ -42,11 +44,17 @@
                                 <MudAvatar Color="color">@abbr</MudAvatar>
                             </CardHeaderAvatar>
                             <CardHeaderContent>
-                                <MudText Typo="Typo.h6">@product.InternalName</MudText>
+                                <MudText Typo="Typo.h6">@product.Title</MudText>
                                 <MudText Typo="Typo.button">@product.Id</MudText>
                             </CardHeaderContent>
                         </MudCardHeader>
                         <MudCardContent>
+                            <MudText>Short Description</MudText>
+                            <MudText Typo="Typo.button">@product.ShortDescription.ToHyphenIfNullOrEmpty()</MudText>
+
+                            <MudText>Description</MudText>
+                            <MudText Typo="Typo.button">@product.Description.ToHyphenIfNullOrEmpty()</MudText>
+
                             <MudText>SKU / Reference</MudText>
                             <MudText Typo="Typo.button">@product.SKU.ToHyphenIfNullOrEmpty()</MudText>
 
@@ -87,8 +95,14 @@
                                             <MudText>Id</MudText>
                                             <MudText Typo="Typo.button">@option.Id.ToHyphenIfNullOrEmpty()</MudText>
 
-                                            <MudText>Name</MudText>
-                                            <MudText Typo="Typo.button">@option.InternalName.ToHyphenIfNullOrEmpty()</MudText>
+                                            <MudText>Title</MudText>
+                                            <MudText Typo="Typo.button">@option.Title.ToHyphenIfNullOrEmpty()</MudText>
+
+                                            <MudText>Short Description</MudText>
+                                            <MudText Typo="Typo.button">@option.ShortDescription.ToHyphenIfNullOrEmpty()</MudText>
+
+                                            <MudText>Description</MudText>
+                                            <MudText Typo="Typo.button">@option.Description.ToHyphenIfNullOrEmpty()</MudText>
 
                                             <MudText>Is Default</MudText>
                                             <MudText Typo="Typo.button">@option.IsDefault.ToString()</MudText>

--- a/FjordTours.App.DistributorApi/Pages/OctoApi/OctoSupplierPage.razor
+++ b/FjordTours.App.DistributorApi/Pages/OctoApi/OctoSupplierPage.razor
@@ -1,9 +1,10 @@
 ﻿@page "/octo/supplier"
+
 @using FjordTours.App.DistributorApi.Components
-@using FjordTours.DistributorApi.Contracts.Octo
-@using FjordTours.DistributorApi.Proprietary.Contracts
 @using FjordTours.DistributorApi.Common.Constants
+@using FjordTours.DistributorApi.Contracts.Octo
 @using FjordTours.OCTO.Common.Dtos.Supplier
+
 @inherits AppProtectedPage
 
 <h1>OCTO API - Supplier</h1>
@@ -15,6 +16,12 @@
         <MudProgressCircular Color="Color.Primary"
                              Size="Size.Large"
                              Indeterminate="true" />
+    }
+    else if (!string.IsNullOrEmpty(_errorMessage))
+    {
+        <MudAlert Severity="Severity.Error">
+            @_errorMessage
+        </MudAlert>
     }
     else if (_supplier is null)
     {
@@ -64,14 +71,30 @@ else
     IOctoContract OctoClient { get; set; } = default!;
 
     bool _isLoading = false;
+    string? _errorMessage { get; set; } = null;
     SupplierDto? _supplier { get; set; } = null;
 
-    protected override async Task OnParametersSetAsync()
+    protected override async Task OnInitializedAsync()
     {
         _isLoading = true;
-        var supplierResult = await OctoClient.GetSupplierAsync();
-        _supplier = supplierResult;
-        _isLoading = false;
+        _errorMessage = null;
+        try
+        {
+            var supplierResult = await OctoClient.GetSupplierAsync();
+            _supplier = supplierResult;
+        }
+        catch (HttpRequestException ex)
+        {
+            _errorMessage = $"Failed to load supplier: {ex.Message}";
+        }
+        catch (Exception ex)
+        {
+            _errorMessage = $"An unexpected error occurred: {ex.Message}";
+        }
+        finally
+        {
+            _isLoading = false;
+        }
     }
 
 }


### PR DESCRIPTION
- Transport products now get exposed in the Octo Api, too. The various origin-destination combinations get exposed as options.
- Additionally, support for octo/content is added.